### PR TITLE
Decrease package size with `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.php export-ignore
+phpunit.xml export-ignore
+php.yml export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to decrease the final package size when required. Like the PR (https://github.com/minicli/minicli/pull/48) I submitted to `minicli/minicli`. The decrease due to this particular `.gitattributes` is barely noticeable but it's a decrease nonetheless. 🙂